### PR TITLE
Added `--noOffsetValidation` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ $ video-sync -h # help page
 
 - `-f, --forceOffset` use the estimated offset as the final offset, no synching
 
+- `-n, --noOffsetValidation` don't check if one of the videos is warped (which could invalidate the offset)
+
 - `-m, --maxOffset=<number>` [default: 120] maximum considered offset between the videos (in seconds) for video syncing.
 
 - `--searchIncrements=<number>` [default: 3] maximum area (video duration, in seconds) to search for the next scene in any direction (forward/backward) before searching in the other direction (requires algorithm=matching-scene)

--- a/src/index.js
+++ b/src/index.js
@@ -249,11 +249,13 @@ class VideoSyncCommand extends Command {
 
     // check if one of the videos is warped
     let videoWarped = false
-    const offsetValidationSpinner = ora(`Checking if found offset applies to the whole video...`).start();
-    try {
-      videoWarped = ! await validateOffset(args.destination, args.source, videoOffset)
-    } catch (err) {
-      console.error(`Error while checking if found offset applies to the whole video:`, err)
+    if (!flags.noOffsetValidation) {
+      const offsetValidationSpinner = ora(`Checking if found offset applies to the whole video...`).start();
+      try {
+        videoWarped = ! await validateOffset(args.destination, args.source, videoOffset)
+      } catch (err) {
+        console.error(`Error while checking if found offset applies to the whole video:`, err)
+      }
     }
 
     // log warning about warped video
@@ -352,6 +354,11 @@ VideoSyncCommand.flags = {
   forceOffset: flags.boolean({
     char: `f`,
     description: `use the estimated offset as the final offset, no synching`,
+    default: false,
+  }),
+  noOffsetValidation: flags.boolean({
+    char: `n`,
+    description: `don't check if one of the videos is warped (which could invalidate the offset)`,
     default: false,
   }),
   maxOffset: flags.integer({


### PR DESCRIPTION
Will skip the offset validation, especially useful in conjunction with `-e` and `-f` in order to skip right to muxing  